### PR TITLE
Memory Management & Anonymous Page 구현

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -114,4 +114,7 @@ void vm_dealloc_page (struct page *page);
 bool vm_claim_page (void *va);
 enum vm_type page_get_type (struct page *page);
 
+unsigned page_hash(const struct hash_elem *p_, void *aux UNUSED);
+bool page_less(const struct hash_elem *a_, const struct hash_elem *b_, void *aux UNUSED);
+
 #endif  /* VM_VM_H */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -57,9 +57,9 @@ struct page {
 #ifdef EFILESYS
 		struct page_cache page_cache;
 #endif
-	};
-
+    };
     struct hash_elem hash_elem;
+    bool writable;
 };
 
 /* The representation of "frame" */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -2,6 +2,7 @@
 #define VM_VM_H
 #include <stdbool.h>
 #include "threads/palloc.h"
+#include "lib/kernel/hash.h"
 
 enum vm_type {
 	/* page not initialized */
@@ -57,12 +58,14 @@ struct page {
 		struct page_cache page_cache;
 #endif
 	};
+
+    struct hash_elem hash_elem;
 };
 
 /* The representation of "frame" */
 struct frame {
-	void *kva;
-	struct page *page;
+    void *kva;
+    struct page *page;
 };
 
 /* The function table for page operations.
@@ -70,21 +73,23 @@ struct frame {
  * Put the table of "method" into the struct's member, and
  * call it whenever you needed. */
 struct page_operations {
-	bool (*swap_in) (struct page *, void *);
-	bool (*swap_out) (struct page *);
-	void (*destroy) (struct page *);
-	enum vm_type type;
+    bool (*swap_in)(struct page *, void *);
+    bool (*swap_out)(struct page *);
+    void (*destroy)(struct page *);
+    enum vm_type type;
 };
 
-#define swap_in(page, v) (page)->operations->swap_in ((page), v)
-#define swap_out(page) (page)->operations->swap_out (page)
-#define destroy(page) \
-	if ((page)->operations->destroy) (page)->operations->destroy (page)
+#define swap_in(page, v) (page)->operations->swap_in((page), v)
+#define swap_out(page) (page)->operations->swap_out(page)
+#define destroy(page)                \
+    if ((page)->operations->destroy) \
+    (page)->operations->destroy(page)
 
 /* Representation of current process's memory space.
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
+    struct hash pages;
 };
 
 #include "threads/thread.h"

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -783,6 +783,7 @@ load_segment(struct file *file, off_t ofs, uint8_t *upage,
         read_bytes -= page_read_bytes;
         zero_bytes -= page_zero_bytes;
         upage += PGSIZE;
+        ofs += read_bytes;
     }
     return true;
 }
@@ -802,7 +803,7 @@ setup_stack(struct intr_frame *if_) {
         return false;
     if (!vm_claim_page(stack_bottom))
         return false;
-    if_->rsp = stack_bottom;
+    if_->rsp = USER_STACK;
     return true;
 }
 #endif /* VM */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -720,7 +720,7 @@ lazy_load_segment(struct page *page, void *aux) {
     uint8_t *kpage = page->frame->kva;
     if (kpage == NULL)
         return false;
-
+    file_seek(info->file, info->offset);
     /* Load this page. */
     if (file_read(info->file, kpage, info->page_read_bytes) != (int)info->page_read_bytes) {
         palloc_free_page(kpage);
@@ -798,7 +798,12 @@ setup_stack(struct intr_frame *if_) {
      * TODO: You should mark the page is stack. */
     /* TODO: Your code goes here */
 
-    return success;
+    if (!vm_alloc_page(VM_ANON | VM_MARKER_0, stack_bottom, true))
+        return false;
+    if (!vm_claim_page(stack_bottom))
+        return false;
+    if_->rsp = stack_bottom;
+    return true;
 }
 #endif /* VM */
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -161,8 +161,9 @@ __do_fork(void *aux) {
     process_activate(current);
 #ifdef VM
     supplemental_page_table_init(&current->spt);
-    if (!supplemental_page_table_copy(&current->spt, &parent->spt))
+    if (!supplemental_page_table_copy(&current->spt, &parent->spt)) {
         goto error;
+    }
 #else
     if (!pml4_for_each(parent->pml4, duplicate_pte, parent))
         goto error;
@@ -723,11 +724,11 @@ lazy_load_segment(struct page *page, void *aux) {
     file_seek(info->file, info->offset);
     /* Load this page. */
     if (file_read(info->file, kpage, info->page_read_bytes) != (int)info->page_read_bytes) {
-        palloc_free_page(kpage);
+        // palloc_free_page(kpage);
         return false;
     }
-    memset(kpage + info->page_read_bytes, 0, info->page_zero_bytes);
-    free(info);
+    // memset(kpage + info->page_read_bytes, 0, info->page_zero_bytes);
+    //  free(info);
     return true;
     // /* Add the page to the process's address space. */
     // if (!install_page(page, kpage, writable))
@@ -775,7 +776,7 @@ load_segment(struct file *file, off_t ofs, uint8_t *upage,
         info->page_zero_bytes = page_zero_bytes;
         info->offset = ofs;
         if (!vm_alloc_page_with_initializer(VM_ANON, upage, writable, lazy_load_segment, info)) {
-            free(info);
+            // free(info);
             return false;
         }
 
@@ -783,7 +784,7 @@ load_segment(struct file *file, off_t ofs, uint8_t *upage,
         read_bytes -= page_read_bytes;
         zero_bytes -= page_zero_bytes;
         upage += PGSIZE;
-        ofs += read_bytes;
+        ofs += page_read_bytes;
     }
     return true;
 }

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -30,6 +30,12 @@ static bool load(const char *file_name, struct intr_frame *if_);
 static void initd(void *f_name);
 static void __do_fork(void *);
 extern struct lock file_lock;
+struct load_info {
+    struct file *file;
+    size_t page_read_bytes;
+    size_t page_zero_bytes;
+    off_t offset;
+};
 /* General process initializer for initd and other process. */
 static void
 process_init(void) {
@@ -710,6 +716,26 @@ lazy_load_segment(struct page *page, void *aux) {
     /* TODO: Load the segment from the file */
     /* TODO: This called when the first page fault occurs on address VA. */
     /* TODO: VA is available when calling this function. */
+    struct load_info *info = (struct load_info *)aux;
+    uint8_t *kpage = page->frame->kva;
+    if (kpage == NULL)
+        return false;
+
+    /* Load this page. */
+    if (file_read(info->file, kpage, info->page_read_bytes) != (int)info->page_read_bytes) {
+        palloc_free_page(kpage);
+        return false;
+    }
+    memset(kpage + info->page_read_bytes, 0, info->page_zero_bytes);
+    free(info);
+    return true;
+    // /* Add the page to the process's address space. */
+    // if (!install_page(page, kpage, writable))
+    // {
+    //     printf("fail\n");
+    //     palloc_free_page(kpage);
+    //     return false;
+    // }
 }
 
 /* Loads a segment starting at offset OFS in FILE at address
@@ -741,10 +767,17 @@ load_segment(struct file *file, off_t ofs, uint8_t *upage,
         size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
         /* TODO: Set up aux to pass information to the lazy_load_segment. */
-        void *aux = NULL;
-        if (!vm_alloc_page_with_initializer(VM_ANON, upage,
-                                            writable, lazy_load_segment, aux))
+        struct load_info *info = malloc(sizeof *info);
+        if (!info)
             return false;
+        info->file = file;
+        info->page_read_bytes = page_read_bytes;
+        info->page_zero_bytes = page_zero_bytes;
+        info->offset = ofs;
+        if (!vm_alloc_page_with_initializer(VM_ANON, upage, writable, lazy_load_segment, info)) {
+            free(info);
+            return false;
+        }
 
         /* Advance. */
         read_bytes -= page_read_bytes;

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -121,7 +121,7 @@ void syscall_handler(struct intr_frame *f UNUSED) {
 }
 
 void check_addr(uint64_t *ptr) {
-    if (ptr == NULL || is_kernel_vaddr(ptr) || !pml4_get_page(thread_current()->pml4, ptr))
+    if (ptr == NULL || is_kernel_vaddr(ptr) || !spt_find_page(&thread_current()->spt, ptr))
         exit(-1);
 }
 

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -8,8 +8,8 @@
  * function.
  * */
 
-#include "vm/uninit.h"
 #include "vm/vm.h"
+#include "vm/uninit.h"
 
 static bool uninit_initialize(struct page *page, void *kva);
 static void uninit_destroy(struct page *page);

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -149,11 +149,13 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
                          bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
     struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
     struct page *page = NULL;
+    struct page _page;
+    _page.va = addr;
     if (!not_present)
         return false; // copy-on-wrtie 구현하면 여기서 함수 호출;
     /* TODO: Validate the fault */
     /* TODO: Your code goes here */
-    struct hash_elem *h = hash_find(&spt->pages, addr);
+    struct hash_elem *h = hash_find(&spt->pages, &_page.hash_elem);
     if (!h)
         return false;
     page = hash_entry(h, struct page, hash_elem);

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -60,9 +60,6 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
         case VM_FILE:
             uninit_new(page, upage, init, type, aux, file_backed_initializer);
             break;
-        // case VM_PAGE_CACHE:
-        //     uninit_new(page, upage, init, type, aux, fil);
-        //     break;
         default:
             break;
         }
@@ -151,8 +148,14 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
                          bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
     struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
     struct page *page = NULL;
+    if (!not_present)
+        return false; // copy-on-wrtie 구현하면 여기서 함수 호출;
     /* TODO: Validate the fault */
     /* TODO: Your code goes here */
+    struct hash_elem *h = hash_find(&spt->pages, addr);
+    if (!h)
+        return false;
+    page = hash_entry(h, struct page, hash_elem);
 
     return vm_do_claim_page(page);
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -53,7 +53,8 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
          * TODO: and then create "uninit" page struct by calling uninit_new. You
          * TODO: should modify the field after calling the uninit_new. */
         struct page *page = calloc(1, sizeof *page);
-        switch (type) {
+        page->writable = writable;
+        switch (VM_TYPE(type)) {
         case VM_ANON:
             uninit_new(page, upage, init, type, aux, anon_initializer);
             break;
@@ -76,7 +77,7 @@ struct page *
 spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
     struct page *page = NULL;
     struct page _page;
-    _page.va = va;
+    _page.va = pg_round_down(va);
     struct hash_elem *find_elem = hash_find(&spt->pages, &_page.hash_elem);
     /* TODO: Fill this function. */
     if (!find_elem)


### PR DESCRIPTION
## Memory Management & Anonymous Page 구현

### vm.h
 - page 구조체에 hash_elem, writable 필드 추가
 - frame 구조체에 kernel virtual adress를 나타내는 kva 멤버 및 page 구조체 포인터 추가
 - supplemental_page_table에 pages hash_table 필드 추가

### process.c
 - lazy_load_segment 함수의 aux 구조체인 load_info struct 추가 
 - lazy_load_segment 함수 구현
     - aux로 받은 load_info (file, page_read_byte, offset)을 이용하여 segment_load 로직 구현
     - kpage는 page와 링크된 frame의 kva로 정의
     - file_seek으로 파일의 오프셋 세팅
     - ELF파일 을 읽고 리턴
- load_segment 함수 구현
   - lazy_load_segment 함수의 인자인 aux를 load_info로 정의
   - vm_alloc_page_initializer()함수를 통해 lazy_load_segment를 init 함수, load_info를 aux로 UNINIT 페이지를 spt에 등록
- setup_stack 함수 구현
   - vm_alloc_page함수를 통해 VM_MARKER_0를 마킹한 ANON타입 페이지 할당
   - 해당 페이지를 claim
   - rsp를 USER_STACK으로 설정 후 리턴

### syscall.c
- check_addr 함수 수정
    - pml4에 페이지가 install 되어 있는지 확인하는 대신 spt에 페이지가 할당 되었는지 확인하는 로직으로 수정

### vm.c
- vm_alloc_page_with_initializer 함수 구현
    - calloc 으로 page 할당
    - VM_TYPE을 통해 타입을 확인하고 해당 타입에 맞는 initialize 함수를 인자로 uninit_new 함수 호출
    - page의 writable 멤버를 인자의 writable로 세팅
    - spt에 페이지를 할당
- spt_find_page 함수 구현
    - 인자로 받은 va를 pg_round_down 메크로로 속한 페이지의 주소로 세팅
    - spt의 pages hash_table에서 해당하는 페이지 찾아서 반환
- spt_insert_page 함수 구현
    - 인자로 받은 페이지를 인자로 받은 spt에 삽입
- vm_get_frame 함수 구현
    - calloc 으로 frame 할당
    - frame->kva에 palloc으로 실제 물리주소 할당 후 frame 리턴
- vm_try_handle_fault 함수 구현
    - not_preset 가  false면 (현재 기준 진짜 page fault) false 리턴
    - page_fault 를 발생시킨 addr페이지를 찾은 뒤 해당 페이지에 프레임 할당 (vm_do_claim_page 함수 호출)
- vm_claim_page 함수 구현
    - va에 맞는 page 찾기
    - 해당 페이지가 없다면 즉시 false 리턴
    - 페이지를 찾았다면 vm_do_claim_page 함수 호출
- vm_do_claim_page 함수 구현
    - vm_get_frame 함수를 통해 frame 얻기
    - 인자로 받은 page와 frame 연결
    - 이후 page의 va와 frame의 kva를 pml4_set_page함수를 통해 페이지 테이블에 매핑
    - 해당 페이지의 swap_in 루틴 실행
- supplemental_page_table_init 함수 구현
    - spt 구조체의 hash_table 멤버 (pages) 초기화
- supplemental_page_table_copy 함수 구현
    - src spt를 순회하며 dst의 spt로 page 복사
    - src 페이지가 uninit 타입이라면 vm_alloc_page_with_initializer 함수 호출 하여 src 페이지와 동일한 uninit페이지를 spt에 할당
    - src 페이지가 uninit 타입이아니라면 vm_alloc_page로 페이지를 하나 할당 받은 뒤 즉시 claim 이후 claim한 페이지에 src_page의 물리주소에 있는 컨텐츠를 복사
- supplemental_page_table_kill 함수 구현
    - hash_clear 함수로 spt의 모든 page를 destroy한다.