### PR TITLE
Stack growth

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -22,7 +22,7 @@ enum thread_status {
 /* Thread identifier type.
    You can redefine this to whatever type you like. */
 typedef int tid_t;
-#define TID_ERROR ((tid_t)-1) /* Error value for tid_t. */
+#define TID_ERROR ((tid_t) - 1) /* Error value for tid_t. */
 
 /* Thread priorities. */
 #define PRI_MIN 0      /* Lowest priority. */
@@ -119,6 +119,7 @@ struct thread {
 #ifdef VM
     /* Table for whole virtual memory owned by thread. */
     struct supplemental_page_table spt;
+    uint64_t user_rsp;
 #endif
 
     /* Owned by thread.c. */

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -140,6 +140,9 @@ page_fault(struct intr_frame *f) {
 
 #ifdef VM
     /* For project 3 and later. */
+    if (user)
+        thread_current()->user_rsp = f->rsp;
+
     if (vm_try_handle_fault(f, fault_addr, user, write, not_present))
         return;
 #endif

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -723,20 +723,10 @@ lazy_load_segment(struct page *page, void *aux) {
         return false;
     file_seek(info->file, info->offset);
     /* Load this page. */
-    if (file_read(info->file, kpage, info->page_read_bytes) != (int)info->page_read_bytes) {
-        // palloc_free_page(kpage);
+    if (file_read(info->file, kpage, info->page_read_bytes) != (int)info->page_read_bytes)
         return false;
-    }
-    // memset(kpage + info->page_read_bytes, 0, info->page_zero_bytes);
-    //  free(info);
+
     return true;
-    // /* Add the page to the process's address space. */
-    // if (!install_page(page, kpage, writable))
-    // {
-    //     printf("fail\n");
-    //     palloc_free_page(kpage);
-    //     return false;
-    // }
 }
 
 /* Loads a segment starting at offset OFS in FILE at address

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -69,6 +69,7 @@ void syscall_handler(struct intr_frame *f UNUSED) {
     uint64_t syscall_num = f->R.rax;
     // TODO: Your implementation goes here.
     struct thread *curr = thread_current();
+    curr->user_rsp = f->rsp;
     switch (syscall_num) {
     case SYS_HALT:
         power_off(); /* Halt the operating system. */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -140,6 +140,11 @@ vm_get_frame(void) {
 /* Growing the stack. */
 static void
 vm_stack_growth(void *addr UNUSED) {
+    vm_alloc_page(VM_ANON | VM_MARKER_0, pg_round_down(addr), true);
+
+    if (vm_claim_page(addr)) {
+        PANIC("todo");
+    }
 }
 
 /* Handle the fault on write_protected page */
@@ -158,8 +163,20 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
     /* TODO: Validate the fault */
     /* TODO: Your code goes here */
     page = spt_find_page(spt, addr);
-    if (!page)
+
+    if (!page) {
+
+        if (pg_round_down(addr) > USER_STACK + PGSIZE - (1 << 20))
+            return false;
+
+        page = spt_find_page(spt, pg_round_up(addr));
+
+        if (page && (page_get_type(page) & VM_MARKER_0)) {
+            vm_stack_growth(addr);
+            return true;
+        }
         return false;
+    }
 
     return vm_do_claim_page(page);
 }
@@ -220,7 +237,7 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
             }
             continue;
         }
-        
+
         vm_alloc_page(src_type, src_page->va, src_page->writable);
 
         vm_claim_page(src_page->va);


### PR DESCRIPTION
## Stack growth 구현

#### thread.h
- thread 구조체에 user_rsp 멤버 추가

#### exception.c
- page_fault 함수 수정
    - user 플래그가 참이면 인자로 넘어온 intr_frame의 rsp를 thread 구조체의 user_rsp로 저장

#### syscall.c
- syscall_handler 함수 수정
    - intr_frame의 rsp를 현재 thread 구조체의 user_rsp에 저장
- read 함수 수정
    - 버퍼의 주소가 속한 page가 read_only인지 검증하는 함수 추가
- check_buffer 함수 구현
    - buffer의 모든 페이지를 순회하여 그 중 writable이 false인 페이지가 있다면 false 리턴

#### vm.c
- vm_stack_growth 함수 구현
    - 인자로 주어진 주소를 page alighe한 주소로 ANON 타입 페이지 alloc 및 claim
- vm_try_handle_fault 함수 수정
    - fault_adress 페이지가 존재하지 않다면, 다음 검증을 거친 후 vm_stack_growth를 호출하여 스택을 확장한다.
        - 스택 최대 크기 (1MB)를 넘지 않는 주소인지 확인
        - 그렇다면 인자로 주어진 addr의 바로 앞 페이지 찾기
        - 위에서 찾은 페이지가 존재하는지 확인
        - 해당 페이지의 타입에 VM_MARKER_0가 마킹 되어있는지 확인
        - 인자로 주어진 addr이 rsp인지 저장되어있는 user_rsp를 통해 확인