### PR TITLE
Implement - Memory Mapped Files

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -68,6 +68,13 @@ struct frame {
     struct page *page;
 };
 
+struct load_info {
+    struct file *file;
+    size_t page_read_bytes;
+    size_t page_zero_bytes;
+    off_t offset;
+};
+
 /* The function table for page operations.
  * This is one way of implementing "interface" in C.
  * Put the table of "method" into the struct's member, and

--- a/tests/vm/mmap-twice.c
+++ b/tests/vm/mmap-twice.c
@@ -20,6 +20,6 @@ void test_main(void) {
     }
 
     for (i = 0; i < 2; i++)
-        CHECK(!memc    mp(actual[i], sample, strlen(sample)),
+        CHECK(!memcmp(actual[i], sample, strlen(sample)),
               "compare mmap'd file %zu against data", i);
 }

--- a/tests/vm/mmap-twice.c
+++ b/tests/vm/mmap-twice.c
@@ -7,22 +7,19 @@
 #include "tests/lib.h"
 #include "tests/main.h"
 
-void
-test_main (void)
-{
-  char *actual[2] = {(char *) 0x10000000, (char *) 0x20000000};
-  size_t i;
-  int handle[2];
+void test_main(void) {
+    char *actual[2] = {(char *)0x10000000, (char *)0x20000000};
+    size_t i;
+    int handle[2];
 
-  for (i = 0; i < 2; i++) 
-    {
-      CHECK ((handle[i] = open ("sample.txt")) > 1,
-             "open \"sample.txt\" #%zu", i);
-      CHECK (mmap (actual[i], 4096, 0, handle[i], 0) != MAP_FAILED,
-             "mmap \"sample.txt\" #%zu at %p", i, (void *) actual[i]);
+    for (i = 0; i < 2; i++) {
+        CHECK((handle[i] = open("sample.txt")) > 1,
+              "open \"sample.txt\" #%zu", i);
+        CHECK(mmap(actual[i], 4096, 0, handle[i], 0) != MAP_FAILED,
+              "mmap \"sample.txt\" #%zu at %p", i, (void *)actual[i]);
     }
 
-  for (i = 0; i < 2; i++)
-    CHECK (!memcmp (actual[i], sample, strlen (sample)),
-           "compare mmap'd file %zu against data", i);
+    for (i = 0; i < 2; i++)
+        CHECK(!memcmp(actual[i], sample, strlen(sample)),
+              "compare mmap'd file %zu against data", i);
 }

--- a/tests/vm/mmap-twice.c
+++ b/tests/vm/mmap-twice.c
@@ -20,6 +20,6 @@ void test_main(void) {
     }
 
     for (i = 0; i < 2; i++)
-        CHECK(!memcmp(actual[i], sample, strlen(sample)),
+        CHECK(!memc    mp(actual[i], sample, strlen(sample)),
               "compare mmap'd file %zu against data", i);
 }

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -30,12 +30,6 @@ static bool load(const char *file_name, struct intr_frame *if_);
 static void initd(void *f_name);
 static void __do_fork(void *);
 extern struct lock file_lock;
-struct load_info {
-    struct file *file;
-    size_t page_read_bytes;
-    size_t page_zero_bytes;
-    off_t offset;
-};
 /* General process initializer for initd and other process. */
 static void
 process_init(void) {

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -64,7 +64,7 @@ void syscall_init(void) {
               FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
     lock_init(&file_lock);
 }
-// halt exit check_addr wait exec fork create remove filesize open close read write
+
 /* The main system call interface */
 void syscall_handler(struct intr_frame *f UNUSED) {
     uint64_t syscall_num = f->R.rax;
@@ -396,13 +396,13 @@ void *mmap(void *addr, size_t length, int writable, int fd, off_t offset) {
     struct file_descriptor *file_descriptor;
     struct file_descriptor *root_descriptor;
 
-    if (!addr)
+    if (!addr || is_kernel_vaddr(addr))
         return NULL;
 
 
     file_descriptor = get_fd(fd, &root_descriptor);
 
-    if (!file_descriptor || length == 0 || file_descriptor->_stdin || file_descriptor->_stdout || pg_ofs(addr) != 0)
+    if (!file_descriptor || length == 0 || file_descriptor->_stdin || file_descriptor->_stdout || pg_ofs(addr) != 0 || pg_ofs(offset) != 0)
         return NULL;
 
     return do_mmap(addr, length, writable, file_descriptor->file, offset);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -399,13 +399,6 @@ void *mmap(void *addr, size_t length, int writable, int fd, off_t offset) {
     if (!addr)
         return NULL;
 
-    // check_addr(addr);
-
-    // for (unsigned i = 0; i < length; i += PGSIZE) {
-    //     check_buffer((uint8_t *)addr + i);
-    // }
-
-    // check_buffer((uint8_t *)addr + length - 1);
 
     file_descriptor = get_fd(fd, &root_descriptor);
 
@@ -417,4 +410,5 @@ void *mmap(void *addr, size_t length, int writable, int fd, off_t offset) {
 
 void munmap(void *addr) {
     do_munmap(addr);
+
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -120,6 +120,9 @@ void syscall_handler(struct intr_frame *f UNUSED) {
     case SYS_MMAP:
         f->R.rax = mmap(f->R.rdi, f->R.rsi, f->R.rdx, f->R.r10, f->R.r8);
         break;
+    case SYS_MUNMAP:
+        munmap(f->R.rdi);
+        break;
     default:
         break;
     }
@@ -410,4 +413,8 @@ void *mmap(void *addr, size_t length, int writable, int fd, off_t offset) {
         return NULL;
 
     return do_mmap(addr, length, writable, file_descriptor->file, offset);
+}
+
+void munmap(void *addr) {
+    do_munmap(addr);
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -1,10 +1,18 @@
 /* file.c: Implementation of memory backed file object (mmaped object). */
 
 #include "vm/vm.h"
-
+#include "threads/mmu.h"
+#include "threads/palloc.h"
+struct load_info {
+    struct file *file;
+    size_t page_read_bytes;
+    size_t page_zero_bytes;
+    off_t offset;
+};
 static bool file_backed_swap_in(struct page *page, void *kva);
 static bool file_backed_swap_out(struct page *page);
 static void file_backed_destroy(struct page *page);
+static bool lazy_load_file(struct page *page, void *aux);
 
 /* DO NOT MODIFY this struct */
 static const struct page_operations file_ops = {
@@ -48,8 +56,55 @@ file_backed_destroy(struct page *page) {
 void *
 do_mmap(void *addr, size_t length, int writable,
         struct file *file, off_t offset) {
+    void *ret = addr;
+
+    size_t read_bytes = length;
+    size_t zero_bytes = length % PGSIZE;
+    while (read_bytes > 0 || zero_bytes > 0) {
+        /* Do calculate how to fill this page.
+         * We will read PAGE_READ_BYTES bytes from FILE
+         * and zero the final PAGE_ZERO_BYTES bytes. */
+        size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
+        size_t page_zero_bytes = PGSIZE - page_read_bytes;
+
+        /* TODO: Set up aux to pass information to the lazy_load_segment. */
+        struct load_info *info = malloc(sizeof *info);
+        if (!info)
+            return NULL;
+        info->file = file;
+        info->page_read_bytes = page_read_bytes;
+        info->page_zero_bytes = page_zero_bytes;
+        info->offset = offset;
+        if (!vm_alloc_page_with_initializer(VM_ANON, addr, writable, lazy_load_file, info)) {
+            return NULL;
+        }
+
+        /* Advance. */
+        read_bytes -= page_read_bytes;
+        zero_bytes -= page_zero_bytes;
+        addr += PGSIZE;
+        offset += page_read_bytes;
+    }
+    return ret;
 }
 
 /* Do the munmap */
 void do_munmap(void *addr) {
+}
+
+static bool
+lazy_load_file(struct page *page, void *aux) {
+    /* TODO: Load the segment from the file */
+    /* TODO: This called when the first page fault occurs on address VA. */
+    /* TODO: VA is available when calling this function. */
+    struct load_info *info = (struct load_info *)aux;
+    uint8_t *kpage = page->frame->kva;
+    if (kpage == NULL)
+        return false;
+    file_seek(info->file, info->offset);
+    /* Load this page. */
+    if (file_read(info->file, kpage, info->page_read_bytes) != (int)info->page_read_bytes)
+        return false;
+
+    return true;
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -45,7 +45,6 @@ file_backed_swap_out(struct page *page) {
 static void
 file_backed_destroy(struct page *page) {
     struct file_page *file_page UNUSED = &page->file;
-    printf("이건 파일 디스트로이\n");
 }
 
 /* Do the mmap */

--- a/vm/file.c
+++ b/vm/file.c
@@ -100,7 +100,7 @@ void do_munmap(void *addr) {
             file_write(info->file, page->frame->kva, info->page_read_bytes);
             pml4_set_dirty(thread_current()->pml4, page->va, 0);
         }
-
+        pml4_clear_page(thread_current()->pml4, page->va);
         /* Advance. */
        
         addr += PGSIZE;

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -64,6 +64,4 @@ uninit_destroy(struct page *page) {
     struct uninit_page *uninit UNUSED = &page->uninit;
     /* TODO: Fill this function.
      * TODO: If you don't have anything to do, just return. */
-    printf("이건 uninit 디스트로이\n");
-    free(uninit->aux);
 }

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -10,6 +10,7 @@
 
 #include "vm/vm.h"
 #include "vm/uninit.h"
+#include "threads/malloc.h"
 
 static bool uninit_initialize(struct page *page, void *kva);
 static void uninit_destroy(struct page *page);
@@ -63,4 +64,6 @@ uninit_destroy(struct page *page) {
     struct uninit_page *uninit UNUSED = &page->uninit;
     /* TODO: Fill this function.
      * TODO: If you don't have anything to do, just return. */
+    printf("이건 uninit 디스트로이\n");
+    free(uninit->aux);
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -261,12 +261,10 @@ void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
 
 static void hash_destroy_support(struct hash_elem *e, void *aux) {
     struct page *p = hash_entry(e, struct page, hash_elem);
-    if (p->operations->type == VM_FILE) {
-        do_munmap(p->va);
-    } else {
+    if (p->operations->type == VM_FILE)
+        write_contents(p->va);
 
-        vm_dealloc_page(p);
-    }
+    vm_dealloc_page(p);
 }
 
 unsigned page_hash(const struct hash_elem *p_, void *aux UNUSED) {

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -98,6 +98,8 @@ bool spt_insert_page(struct supplemental_page_table *spt UNUSED,
 }
 
 void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
+    page->frame->page = NULL;
+    hash_delete(&spt->pages, &page->hash_elem);
     vm_dealloc_page(page);
     return true;
 }


### PR DESCRIPTION
# Memory Mapped Files 구현


### vm.h
-  여러 파일에서 load_info 구조체를 사용하기 위해 선언 위치 조정
    -  userprog/process.c -> vm.h
---
### process.c
- load_info 구조체 삭제
---
### userprog/syscall.c
- syscall_handler 함수 수정
    - Memory Mapped 를 위한 시스템 콜 케이스 mmap 과 munmap 추가 
- mmap 함수 추가
    -  적합한 요청인지 확인   
         -  맵핑을 요청한 주소가 NULL 이 아니고 커널 영역이 아닌지 확인
         -  fd로 열린 파일인지 확인, 컨솔 입출력이 아닌지 확인
         -  요청 길이가 0이 아닌지 확인, 요청 주소 및 오프셋이 페이지 정렬이 되어있는지 확인.
    -  적합한 요청일 경우만 do_mmap 을 호출
-  munmap 함수추가
    - do_munmap 함수 호출
---

### file.c
- do_mmap 함수 내부 구현
    -  각 매핑에 대해 독립적인 참조를 얻기 위해 파일을 reopen
    -  do_mmap에 요청온 length를 PGSIZE 단위로 페이지 생성 및 초기화
        -  lazy_load_file 함수에 필요한 load_info 구조체 초기화
        -  type이 VM_FILE 이고, lazy_load 방식으로 동작하도록 페이지 생성
        -  맵핑 요청온 주소값 반환
- do_munmap 함수 내부 구현
    - 요청 온 주소에 해당하는 페이지를 찾음 , 페이지를 못 찾으면 NULL 반환
    - 변경 사항이 있는지 확인하고, 변경사항이 있다면 변경된 내용을 파일에 업데이트
    -  변경내용 기록 끝났으면 dirty 비트 초기화
    -  다음 페이지가 안나올 때까지 위의 내용 반복 
- lazy_load_file 함수 추가 및 구현
    - aux로 받은 load_info (file, page_read_byte, offset)을 이용하여 segment_load 로직 구현
    - kpage는 page와 링크된 frame의 kva로 정의
    - file_seek으로 파일의 오프셋 세팅
    - ELF파일을 읽고 리턴  
---
### vm.c
- vm_alloc_page_with_initializer 함수 수정
    - calloc 실패시 예외 추가
- spt_remove_page 함수 수정
    - 해쉬테이블에서도 페이지 정보가 삭제 되도록 수정
- supplemental_page_table_kill 함수 수정
    -  해쉬테이블을 순회하면서 페이지의 타입이 VM_FILE인 페이지에 대해서 수정이 되었다면 수정내용을 파일에 반영
        - wirte_contents() 함수 호출  
    -  페이지 타입이 VM_FILE 이면 물리페이지와 맵핑을 제거
- wirte_contents 함수 추가
    - uninit 구조체에 존재하는 aux 정보 이용 
        - file_seek으로 파일의 오프셋 세팅
        - file_write 이용해서 파라미터로 들어온 페이지의 내용 기록  