### PR TITLE
Implement - Swap IN / Out

### DIFF
--- a/include/devices/disk.h
+++ b/include/devices/disk.h
@@ -6,6 +6,7 @@
 
 /* Size of a disk sector in bytes. */
 #define DISK_SECTOR_SIZE 512
+#define DISK_SLOT_SIZE 512 * 8
 
 /* Index of a disk sector within a disk.
  * Good enough for disks up to 2 TB. */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -5,24 +5,24 @@
 #include "lib/kernel/hash.h"
 
 enum vm_type {
-	/* page not initialized */
-	VM_UNINIT = 0,
-	/* page not related to the file, aka anonymous page */
-	VM_ANON = 1,
-	/* page that realated to the file */
-	VM_FILE = 2,
-	/* page that hold the page cache, for project 4 */
-	VM_PAGE_CACHE = 3,
+    /* page not initialized */
+    VM_UNINIT = 0,
+    /* page not related to the file, aka anonymous page */
+    VM_ANON = 1,
+    /* page that realated to the file */
+    VM_FILE = 2,
+    /* page that hold the page cache, for project 4 */
+    VM_PAGE_CACHE = 3,
 
-	/* Bit flags to store state */
+    /* Bit flags to store state */
 
-	/* Auxillary bit flag marker for store information. You can add more
-	 * markers, until the value is fit in the int. */
-	VM_MARKER_0 = (1 << 3),
-	VM_MARKER_1 = (1 << 4),
+    /* Auxillary bit flag marker for store information. You can add more
+     * markers, until the value is fit in the int. */
+    VM_MARKER_0 = (1 << 3),
+    VM_MARKER_1 = (1 << 4),
 
-	/* DO NOT EXCEED THIS VALUE. */
-	VM_MARKER_END = (1 << 31),
+    /* DO NOT EXCEED THIS VALUE. */
+    VM_MARKER_END = (1 << 31),
 };
 
 #include "vm/uninit.h"
@@ -42,30 +42,33 @@ struct thread;
  * uninit_page, file_page, anon_page, and page cache (project4).
  * DO NOT REMOVE/MODIFY PREDEFINED MEMBER OF THIS STRUCTURE. */
 struct page {
-	const struct page_operations *operations;
-	void *va;              /* Address in terms of user space */
-	struct frame *frame;   /* Back reference for frame */
+    const struct page_operations *operations;
+    void *va;            /* Address in terms of user space */
+    struct frame *frame; /* Back reference for frame */
 
-	/* Your implementation */
+    /* Your implementation */
 
-	/* Per-type data are binded into the union.
-	 * Each function automatically detects the current union */
-	union {
-		struct uninit_page uninit;
-		struct anon_page anon;
-		struct file_page file;
+    /* Per-type data are binded into the union.
+     * Each function automatically detects the current union */
+    union {
+        struct uninit_page uninit;
+        struct anon_page anon;
+        struct file_page file;
 #ifdef EFILESYS
-		struct page_cache page_cache;
+        struct page_cache page_cache;
 #endif
     };
     struct hash_elem hash_elem;
     bool writable;
+    bool is_last_file_page;
+    size_t slot_idx;
 };
 
 /* The representation of "frame" */
 struct frame {
     void *kva;
     struct page *page;
+    struct list_elem elem;
 };
 
 struct load_info {
@@ -100,28 +103,28 @@ struct supplemental_page_table {
 };
 
 #include "threads/thread.h"
-void supplemental_page_table_init (struct supplemental_page_table *spt);
-bool supplemental_page_table_copy (struct supplemental_page_table *dst,
-		struct supplemental_page_table *src);
-void supplemental_page_table_kill (struct supplemental_page_table *spt);
-struct page *spt_find_page (struct supplemental_page_table *spt,
-		void *va);
-bool spt_insert_page (struct supplemental_page_table *spt, struct page *page);
-void spt_remove_page (struct supplemental_page_table *spt, struct page *page);
+void supplemental_page_table_init(struct supplemental_page_table *spt);
+bool supplemental_page_table_copy(struct supplemental_page_table *dst,
+                                  struct supplemental_page_table *src);
+void supplemental_page_table_kill(struct supplemental_page_table *spt);
+struct page *spt_find_page(struct supplemental_page_table *spt,
+                           void *va);
+bool spt_insert_page(struct supplemental_page_table *spt, struct page *page);
+void spt_remove_page(struct supplemental_page_table *spt, struct page *page);
 
-void vm_init (void);
-bool vm_try_handle_fault (struct intr_frame *f, void *addr, bool user,
-		bool write, bool not_present);
+void vm_init(void);
+bool vm_try_handle_fault(struct intr_frame *f, void *addr, bool user,
+                         bool write, bool not_present);
 
 #define vm_alloc_page(type, upage, writable) \
-	vm_alloc_page_with_initializer ((type), (upage), (writable), NULL, NULL)
-bool vm_alloc_page_with_initializer (enum vm_type type, void *upage,
-		bool writable, vm_initializer *init, void *aux);
-void vm_dealloc_page (struct page *page);
-bool vm_claim_page (void *va);
-enum vm_type page_get_type (struct page *page);
+    vm_alloc_page_with_initializer((type), (upage), (writable), NULL, NULL)
+bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
+                                    bool writable, vm_initializer *init, void *aux);
+void vm_dealloc_page(struct page *page);
+bool vm_claim_page(void *va);
+enum vm_type page_get_type(struct page *page);
 
 unsigned page_hash(const struct hash_elem *p_, void *aux UNUSED);
 bool page_less(const struct hash_elem *a_, const struct hash_elem *b_, void *aux UNUSED);
 
-#endif  /* VM_VM_H */
+#endif /* VM_VM_H */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -350,7 +350,9 @@ process_cleanup(void) {
     struct thread *curr = thread_current();
 
     if (curr->exec_file != NULL) {
+        lock_acquire(&file_lock);
         file_close(curr->exec_file);
+        lock_release(&file_lock);
         curr->exec_file = NULL;
     }
 

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -3,7 +3,12 @@
 #include "devices/disk.h"
 #include "vm/vm.h"
 #include "lib/kernel/bitmap.h"
+#include "threads/mmu.h"
 #include "threads/vaddr.h"
+#include "threads/synch.h"
+
+extern struct lock frame_lock;
+struct lock swap_lock;
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
@@ -24,7 +29,10 @@ static const struct page_operations anon_ops = {
 void vm_anon_init(void) {
     /* TODO: Set up the swap_disk. */
     swap_disk = disk_get(1, 1);
-    sdt = bitmap_create(disk_size(swap_disk) / (PGSIZE / DISK_SECTOR_SIZE)); // 전체 slot 수
+    size_t swap_size = disk_size(swap_disk) / (PGSIZE / DISK_SECTOR_SIZE);
+    sdt = bitmap_create(swap_size); // 전체 slot 수
+    bitmap_set_all(sdt, true);
+    lock_init(&swap_lock);
 }
 
 /* Initialize the file mapping */
@@ -39,24 +47,48 @@ bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
 static bool
 anon_swap_in(struct page *page, void *kva) {
     struct anon_page *anon_page = &page->anon;
-    disk_read(swap_disk, (page->slot_idx) * DISK_SLOT_SIZE, kva);
+    lock_acquire(&swap_lock);
+    for (int i = 0; i < 8; i++) {
+        disk_read(swap_disk, (page->slot_idx) * 8 + i, kva + (i * DISK_SECTOR_SIZE));
+    }
+    bitmap_flip(sdt, page->slot_idx);
+    lock_release(&swap_lock);
+    return true;
 }
 
 /* Swap out the page by writing contents to the swap disk. */
 static bool
 anon_swap_out(struct page *page) {
     struct anon_page *anon_page = &page->anon;
-    size_t slot_idx = bitmap_scan_and_flip(sdt, 0, 1, false);
-    if (slot_idx == BITMAP_ERROR)
+    lock_acquire(&swap_lock);
+    size_t slot_idx = bitmap_scan_and_flip(sdt, 0, 1, true);
+    if (slot_idx == BITMAP_ERROR) {
+        lock_release(&swap_lock);
         return false;
+    }
+    lock_release(&swap_lock);
 
     page->slot_idx = slot_idx;
-    disk_write(swap_disk, slot_idx * DISK_SLOT_SIZE, page->frame->kva);
+    lock_acquire(&swap_lock);
+
+    for (int i = 0; i < 8; i++) {
+        disk_write(swap_disk, slot_idx * 8 + i, (page->frame->kva) + (i * DISK_SECTOR_SIZE));
+    }
+
+    lock_release(&swap_lock);
     pml4_clear_page(thread_current()->pml4, page->va);
+
+    return true;
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */
 static void
 anon_destroy(struct page *page) {
     struct anon_page *anon_page = &page->anon;
+    lock_acquire(&swap_lock);
+    bitmap_set(sdt, page->slot_idx, true);
+    lock_release(&swap_lock);
+    lock_acquire(&frame_lock);
+    list_remove(&page->frame->elem);
+    lock_release(&frame_lock);
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -71,9 +71,11 @@ file_backed_swap_out(struct page *page) {
 static void
 file_backed_destroy(struct page *page) {
     struct file_page *file_page UNUSED = &page->file;
-    lock_acquire(&frame_lock);
-    list_remove(&page->frame->elem);
-    lock_release(&frame_lock);
+    if (page->frame->page == page) {
+        lock_acquire(&frame_lock);
+        list_remove(&page->frame->elem);
+        lock_release(&frame_lock);
+    }
 }
 
 /* Do the mmap */

--- a/vm/file.c
+++ b/vm/file.c
@@ -88,9 +88,12 @@ do_mmap(void *addr, size_t length, int writable,
         if (!vm_alloc_page_with_initializer(VM_FILE, addr, writable, lazy_load_file, info)) {
             return NULL;
         }
-
         /* Advance. */
         read_bytes -= page_read_bytes;
+        if (!read_bytes) {
+            struct page *last_file_page = spt_find_page(&thread_current()->spt, addr);
+            last_file_page->is_last_file_page = true;
+        }
         zero_bytes -= page_zero_bytes;
         addr += PGSIZE;
         offset += page_read_bytes;
@@ -124,7 +127,6 @@ void do_munmap(void *addr) {
         spt_remove_page(&thread_current()->spt, page);
         page = spt_find_page(&thread_current()->spt, addr);
     }
-
     file_close(info->file);
 }
 

--- a/vm/file.c
+++ b/vm/file.c
@@ -9,6 +9,8 @@ static bool file_backed_swap_out(struct page *page);
 static void file_backed_destroy(struct page *page);
 static bool lazy_load_file(struct page *page, void *aux);
 
+struct lock file_swap_lock;
+extern struct lock frame_lock;
 /* DO NOT MODIFY this struct */
 static const struct page_operations file_ops = {
     .swap_in = file_backed_swap_in,
@@ -19,6 +21,7 @@ static const struct page_operations file_ops = {
 
 /* The initializer of file vm */
 void vm_file_init(void) {
+    lock_init(&file_swap_lock);
 }
 
 /* Initialize the file backed page */
@@ -41,27 +44,36 @@ file_backed_swap_in(struct page *page, void *kva) {
     file_seek(info->file, info->offset);
 
     /* Load this page. */
+    lock_acquire(&file_swap_lock);
+    file_seek(info->file, info->offset);
     file_read(info->file, kpage, info->page_read_bytes);
+    lock_release(&file_swap_lock);
+    return true;
 }
 
 /* Swap out the page by writeback contents to the file. */
 static bool
 file_backed_swap_out(struct page *page) {
     struct file_page *file_page UNUSED = &page->file;
-
     struct load_info *info = page->uninit.aux;
     if (pml4_is_dirty(thread_current()->pml4, page->va)) {
+        lock_acquire(&file_swap_lock);
         file_seek(info->file, info->offset);
         file_write(info->file, page->frame->kva, info->page_read_bytes);
+        lock_release(&file_swap_lock);
         pml4_set_dirty(thread_current()->pml4, page->va, 0);
     }
     pml4_clear_page(thread_current()->pml4, page->va);
+    return true;
 }
 
 /* Destory the file backed page. PAGE will be freed by the caller. */
 static void
 file_backed_destroy(struct page *page) {
     struct file_page *file_page UNUSED = &page->file;
+    lock_acquire(&frame_lock);
+    list_remove(&page->frame->elem);
+    lock_release(&frame_lock);
 }
 
 /* Do the mmap */
@@ -70,7 +82,6 @@ do_mmap(void *addr, size_t length, int writable,
         struct file *file, off_t offset) {
     void *ret = addr;
     struct file *mapping_file = file_reopen(file);
-
     size_t read_bytes = length;
     size_t zero_bytes = PGSIZE - (length % PGSIZE);
     while (read_bytes > 0 || zero_bytes > 0) {
@@ -116,8 +127,10 @@ void do_munmap(void *addr) {
         info = page->uninit.aux;
 
         if (pml4_is_dirty(thread_current()->pml4, page->va)) {
+            lock_acquire(&file_swap_lock);
             file_seek(info->file, info->offset);
             file_write(info->file, page->frame->kva, info->page_read_bytes);
+            lock_release(&file_swap_lock);
             pml4_set_dirty(thread_current()->pml4, page->va, 0);
         }
         pml4_clear_page(thread_current()->pml4, page->va);
@@ -139,9 +152,12 @@ lazy_load_file(struct page *page, void *aux) {
     uint8_t *kpage = page->frame->kva;
     if (kpage == NULL)
         return false;
+    lock_acquire(&file_swap_lock);
     file_seek(info->file, info->offset);
 
     /* Load this page. */
     file_read(info->file, kpage, info->page_read_bytes);
+    lock_release(&file_swap_lock);
+
     return true;
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -313,5 +313,7 @@ static void write_contents(struct page *page) {
     struct load_info *info = (struct load_info *)page->uninit.aux;
     file_seek(info->file, info->offset);
     file_write(info->file, page->frame->kva, info->page_read_bytes);
-    // file_close(info->file);
+    if (page->is_last_file_page) {
+        file_close(info->file);
+    }
 }


### PR DESCRIPTION
## Implement Swap IN / Out

#### disk.h
- DISK_SLOT_SIZE 상수 정의 -> swap disk 의 page aligne을 위한 값 (4096)
---
#### vm.h
- page 구조체에 멤버 추가
    - bool is_last_file_page -> memory mapped file에서 매핑된 파일의 마지막 페이지를 나타내는 멤버
    - size_t slot_idx -> anonymous page 스왑시 사용되는 swap disk table의 인덱스
---
#### process.c
- process_cleanup 함수에서 exec_file을 닫을 때 lock을 사용하도록 수정
---
#### anon.c
- swap_lock 선언
- sdt 선언 -> swap disk table로 bitmap 자료구조 이용
- anon_init 함수 구현
    - swap_lock 초기화
    - swap_disk 사이즈 계산 
    - sdt 초기화
- anon_swap_in 함수 구현
     - page의 slot_idx 부터 4kb 만큼 스왑디스크를 읽어 page의 kva에 저장
     - sdt에 해당 인덱스 flip
- anon_swap_out 함수 구현
    - 사용 가능한 스왑 디스크 영역을 sdt에서 scan 하고 해당 slot_idx를 flip
    - 위에서 얻은 slot_idx를 인자로 받은 page에 저장
    - 해당 slot_idx부터 4kb만큼 인자로 받은 페이지의 프레임에 있는 컨텐츠를 디스크에 쓴다.
    - 해당 페이지의 page table mapping을 클리어 한 뒤 리턴
- anon_destroy 함수 구현
    - 인자로 받은 페이지의 slot_idx를 sdt에서 사용 가능으로 표시
    - 인자로 받은 페이지의 프레임을 프레임 리스트에서 제거
---
#### file.c
- file_swap_lock 선언
- vm_file_init 함수 구현
    - file_swap_lock 초기화
- file_backed_swap_in 함수 구현
    - aux에서 load_info 가져온다.
    - file_seek 함수와 load_info를 통해 해당 페이지에 맞는 offset으로 설정
    - file_read를 통해 인자로 받은 프레임의 물리페이지에 파일 읽고 리턴
- file_backed_swap_out 함수 구현
    - aux에서 load_info 가져온다.
    - 인자로 받은 페이지의 dirty bit를 확인 한다.
    - dirty라면 해당 페이지의 프레임에 있는 컨텐츠를 파일에 쓰고, dirty bit을 0으로 설정
    - 해당 페이지의 page table mapping을 클리어 한 뒤 리턴
- file_backed_destroy 함수 구현
    - page와 frame이 정상적으로 link가 되어 있는지 확인
    - 링크가 정상적이라면 해당 페이지의 프레임을 프레임 리스트에서 제거
- do_mmap 함수 수정
    - last_file_page를 확인 하여 해당 페이지의 is_last_file_page를 true로 업데이트
    - filesys 관련 코드 호출 시 lock 사용
- lazy_load_file 함수 수정
    - filesys 관련 코드 호출 시 lock 사용
---
#### vm.c
- frame_list 전역 변수 선언
- frame_lock 전역 변수 선언
- vm_init함수 수정
    - frame_list 초기화
    - frame_lock 초기화
- vm_get_victim 함수 구현
    - clock 알고리즘을 통해 victim frame 리턴
- vm_evict_frame 함수 구현
    - vm_get_victim 함수 호출로 victim 선정
    - victim을 swap_out후 해당 물리프레임의 값을 모두 0으로 초기화 후 victim 리턴
- vm_get_frame 함수 수정
    - frame 할당 실패시 (물리 메모리 부족) vm_evict_frame을 통해 swap_out된 frame을 리턴
- supplemental_page_table_copy 함수 수정
    - file_backed 메모리 페이지 할당시 src의 aux를 복사 할 수 있도록 수정

