### PR TITLE
Implement - Copy on write

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -61,6 +61,7 @@ struct page {
     struct hash_elem hash_elem;
     bool writable;
     bool is_last_file_page;
+    bool copy_on_write;
     size_t slot_idx;
 };
 
@@ -69,6 +70,7 @@ struct frame {
     void *kva;
     struct page *page;
     struct list_elem elem;
+    int ref_count;
 };
 
 struct load_info {
@@ -126,5 +128,6 @@ enum vm_type page_get_type(struct page *page);
 
 unsigned page_hash(const struct hash_elem *p_, void *aux UNUSED);
 bool page_less(const struct hash_elem *a_, const struct hash_elem *b_, void *aux UNUSED);
+void free_frame(struct frame *frame);
 
 #endif /* VM_VM_H */

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -388,7 +388,7 @@ void check_buffer(uint64_t *buffer) {
     struct page *p = spt_find_page(&thread_current()->spt, buffer);
     if (!p)
         exit(-1);
-    if (!p->writable)
+    if (!p->writable && !p->copy_on_write)
         exit(-1);
 }
 

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -88,7 +88,8 @@ anon_destroy(struct page *page) {
     lock_acquire(&swap_lock);
     bitmap_set(sdt, page->slot_idx, true);
     lock_release(&swap_lock);
-    lock_acquire(&frame_lock);
-    list_remove(&page->frame->elem);
-    lock_release(&frame_lock);
+    if (page->frame && page->frame->page == page) {
+        free_frame(page->frame);
+    }
+    pml4_clear_page(thread_current()->pml4, page->va);
 }


### PR DESCRIPTION
## Implement - Copy on write

#### vm.h
- page 구조체에 copy_on_write 멤버(이 페이지가 copy 됐는 지여부) 추가
- frame 구조체 ref_count 멤버 (이 프레임을 참조하는 페이지 수)추가
---
#### syscall.c
- check_buffer 함수 수정
    - page의 writable 여부와 copy_on_write 여부 함께 검사
---
#### anon.c
- anon_destroy 함수 수정
    - frame을 list에서 제거하는 로직 제거
    - 해당 로직을 free_frame 함수로 대체
    - 인자로 받은 페이지 테이블 매핑을 해제
---
#### file.c
- file_backed_swap_out 함수 수정
    - page null 체크 추가
    - file_seek을 사용하던 로직을 file_write_at으로 변경
    - page와 frame의 링크 해제
- file_backed_destroy 함수 수정
    - destroy 호출 시 contents를 file에 쓰는 로직 추가
    - frame을 list에서 제거하는 로직 제거
    - 해당 로직을 free_frame 함수로 대체
    - 인자로 받은 페이지 테이블 매핑을 해제
---
#### vm.c
- vm_evict_frame 함수 수정
    - swap_out 후 victim의 ref_count를 1로 변경하는 로직 추가
- vm_get_frame 함수 수정
    - 프레임 할당시 victim의 ref_count를 1로 초기화
- vm_handle_wp 함수 구현
    - 인자로 받은 page의 copy_on_write이 false면 false 리턴
    - page에 링크된 frame의 ref_count가 1보다 크면
    - vm_get_frame을 통해 새로운 프레임 할당
    - 기존의 프레임의 모든 컨텐츠를 새로운 프레임으로 복사
    - 프레임의 ref_count를 1로 초기화
    - 기존의 페이지 테이블 매핑 정보 클리어
    - 새로 할당받은 프레임으로 페이지 테이블 매핑
- vm_try_handle_fault 함수 수정
    - r/o 페이지에 대한 쓰기 접근으로 인한 fault를 vm_handle_wp 함수 호출로 핸들링 하도록 수정
- supplemental_page_table_copy 함수 수정
    - file_backed 페이지 복사 시 load_info를 새로 할당받아서 전달하도록 수정
    - 페이지 할당후 claim하는 로직 제거
    - src page의 모든 필드를 복사 하고 copy_on_write 필드는 true로 설정
    - frame의 ref_count 증가
    - dst page도 src page와 동일한 프레임을 가르키도록 로직 수정
- supplemental_page_table_kill 함수 수정
   - file_backed 메모리의 write 컨텐츠 로직을 제거 (destroy에서 하므로)
- free_frame 함수 구현
    - frame의 ref_count가 1보다 크면 ref_count 감소
    - 그렇지 않다면 해당 프레임을 프레임 리스트에서 제거하고, palloc_free후 구조체까지 free